### PR TITLE
Complete Dependency Injection Migration and Add Device Defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,4 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+.vscode/settings.json

--- a/userinterface/App.axaml.cs
+++ b/userinterface/App.axaml.cs
@@ -64,7 +64,11 @@ public partial class App : Application
     {
         return new Bootstrapper()
         {
-            BackEndLoader = new BackEndLoader(System.AppDomain.CurrentDomain.BaseDirectory),
+            BackEndLoader = new BackEndLoader(
+                System.AppDomain.CurrentDomain.BaseDirectory,
+                new DevicesReaderWriter(),
+                new MappingsReaderWriter(),
+                new ProfileReaderWriter()),
             DevicesToLoad =
             [
                 new DATA.Device() { Name = "Superlight 2", DPI = 32000, HWID = @"HID\VID_046D&PID_C54D&MI_00", PollingRate = 1000, DeviceGroup = "Logitech Mice" },

--- a/userinterface/App.axaml.cs
+++ b/userinterface/App.axaml.cs
@@ -7,6 +7,7 @@ using System;
 using userinterface.ViewModels;
 using userinterface.Views;
 using userspace_backend;
+using userspace_backend.IO;
 using DATA = userspace_backend.Data;
 
 namespace userinterface;
@@ -20,8 +21,23 @@ public partial class App : Application
 
     public override void OnFrameworkInitializationCompleted()
     {
+        // Create the DI container
         ServiceCollection services = new ServiceCollection();
+
+        // Register BackEndLoader first with settings directory
+        string settingsDirectory = System.AppDomain.CurrentDomain.BaseDirectory;
+        services.AddSingleton<IBackEndLoader>(sp =>
+        {
+            var devicesRW = sp.GetRequiredService<DevicesReaderWriter>();
+            var mappingsRW = sp.GetRequiredService<MappingsReaderWriter>();
+            var profileRW = sp.GetRequiredService<ProfileReaderWriter>();
+            return new BackEndLoader(settingsDirectory, devicesRW, mappingsRW, profileRW);
+        });
+
+        // Compose all other services
         IServiceProvider serviceProvider = BackEndComposer.Compose(services);
+
+        // Resolve and initialize BackEnd
         IBackEnd backEnd = serviceProvider.GetRequiredService<IBackEnd>();
         backEnd.Load();
 

--- a/userinterface/ViewModels/Device/DeviceGroupSelectorViewModel.cs
+++ b/userinterface/ViewModels/Device/DeviceGroupSelectorViewModel.cs
@@ -7,14 +7,14 @@ namespace userinterface.ViewModels.Device
     {
         protected string selectedEntry = null!;
 
-        public DeviceGroupSelectorViewModel(DeviceModel device, DeviceGroups deviceGroupsBE)
+        public DeviceGroupSelectorViewModel(IDeviceModel device, DeviceGroups deviceGroupsBE)
         {
             Device = device;
             DeviceGroupsBE = deviceGroupsBE;
             RefreshSelectedDeviceGroup();
         }
 
-        protected DeviceModel Device { get; }
+        protected IDeviceModel Device { get; }
         protected DeviceGroups DeviceGroupsBE { get; }
 
         public ObservableCollection<string> DeviceGroupEntries =>
@@ -27,7 +27,7 @@ namespace userinterface.ViewModels.Device
             {
                 if (DeviceGroupEntries.Contains(value))
                 {
-                    Device.DeviceGroup.TryUpdateUserInput(value);
+                    Device.DeviceGroup.TryUpdateModelDirectly(value);
                     selectedEntry = value;
                 }
             }

--- a/userinterface/ViewModels/Device/DeviceGroupSelectorViewModel.cs
+++ b/userinterface/ViewModels/Device/DeviceGroupSelectorViewModel.cs
@@ -5,7 +5,7 @@ namespace userinterface.ViewModels.Device
 {
     public partial class DeviceGroupSelectorViewModel : ViewModelBase
     {
-        protected DeviceGroupModel selectedEntry = null!;
+        protected string selectedEntry = null!;
 
         public DeviceGroupSelectorViewModel(DeviceModel device, DeviceGroups deviceGroupsBE)
         {
@@ -17,17 +17,17 @@ namespace userinterface.ViewModels.Device
         protected DeviceModel Device { get; }
         protected DeviceGroups DeviceGroupsBE { get; }
 
-        public ObservableCollection<DeviceGroupModel> DeviceGroupEntries =>
+        public ObservableCollection<string> DeviceGroupEntries =>
             DeviceGroupsBE.DeviceGroupModels;
 
-        public DeviceGroupModel SelectedEntry
+        public string SelectedEntry
         {
             get => selectedEntry;
             set
             {
                 if (DeviceGroupEntries.Contains(value))
                 {
-                    Device.DeviceGroup = value;
+                    Device.DeviceGroup.TryUpdateUserInput(value);
                     selectedEntry = value;
                 }
             }
@@ -37,7 +37,7 @@ namespace userinterface.ViewModels.Device
 
         public void RefreshSelectedDeviceGroup()
         {
-            if (!DeviceGroupEntries.Contains(Device.DeviceGroup))
+            if (!DeviceGroupEntries.Contains(Device.DeviceGroup.ModelValue))
             {
                 IsValid = false;
                 SelectedEntry = DeviceGroups.DefaultDeviceGroup;
@@ -45,7 +45,7 @@ namespace userinterface.ViewModels.Device
             }
 
             IsValid = true;
-            selectedEntry = Device.DeviceGroup;
+            selectedEntry = Device.DeviceGroup.ModelValue;
         }
     }
 }

--- a/userinterface/ViewModels/Device/DeviceGroupViewModel.cs
+++ b/userinterface/ViewModels/Device/DeviceGroupViewModel.cs
@@ -5,13 +5,13 @@ namespace userinterface.ViewModels.Device
 {
     public partial class DeviceGroupViewModel : ViewModelBase
     {
-        public DeviceGroupViewModel(BE.DeviceGroupModel deviceGroupBE, BE.DeviceGroups deviceGroupsBE)
+        public DeviceGroupViewModel(string deviceGroupBE, BE.DeviceGroups deviceGroupsBE)
         {
             DeviceGroupBE = deviceGroupBE;
             DeviceGroupsBE = deviceGroupsBE;
         }
 
-        public BE.DeviceGroupModel DeviceGroupBE { get; }
+        public string DeviceGroupBE { get; }
 
         protected BE.DeviceGroups DeviceGroupsBE { get; }
 

--- a/userinterface/ViewModels/Device/DeviceGroupsViewModel.cs
+++ b/userinterface/ViewModels/Device/DeviceGroupsViewModel.cs
@@ -16,17 +16,17 @@ namespace userinterface.ViewModels.Device
 
         protected BE.DeviceGroups DeviceGroupsBE { get; }
 
-        public ObservableCollection<BE.DeviceGroupModel> DeviceGroups => DeviceGroupsBE.DeviceGroupModels;
+        public ObservableCollection<string> DeviceGroups => DeviceGroupsBE.DeviceGroupModels;
 
         public ObservableCollection<DeviceGroupViewModel> DeviceGroupViews { get; }
 
-        private void DeviceGroupsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e) => 
+        private void DeviceGroupsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e) =>
             UpdateDeviceGroupViews();
 
         public void UpdateDeviceGroupViews()
         {
             DeviceGroupViews.Clear();
-            foreach (BE.DeviceGroupModel deviceGroup in DeviceGroupsBE.DeviceGroupModels)
+            foreach (string deviceGroup in DeviceGroupsBE.DeviceGroupModels)
             {
                 DeviceGroupViews.Add(new DeviceGroupViewModel(deviceGroup, DeviceGroupsBE));
             }

--- a/userinterface/ViewModels/Device/DeviceViewModel.cs
+++ b/userinterface/ViewModels/Device/DeviceViewModel.cs
@@ -6,7 +6,7 @@ namespace userinterface.ViewModels.Device
 {
     public partial class DeviceViewModel : ViewModelBase
     {
-        public DeviceViewModel(BE.DeviceModel deviceBE, BE.DevicesModel devicesBE)
+        public DeviceViewModel(BE.IDeviceModel deviceBE, BE.DevicesModel devicesBE)
         {
             DeviceBE = deviceBE;
             DevicesBE = devicesBE;
@@ -18,7 +18,7 @@ namespace userinterface.ViewModels.Device
             DeviceGroup = new DeviceGroupSelectorViewModel(DeviceBE, DevicesBE.DeviceGroups);
         }
 
-        protected BE.DeviceModel DeviceBE { get; }
+        protected BE.IDeviceModel DeviceBE { get; }
 
         protected BE.DevicesModel DevicesBE { get; }
 
@@ -36,7 +36,7 @@ namespace userinterface.ViewModels.Device
 
         public void DeleteSelf()
         {
-            bool success = DevicesBE.RemoveDevice(DeviceBE);
+            bool success = DevicesBE.TryRemoveElement(DeviceBE);
             Debug.Assert(success);
         }
     }

--- a/userinterface/ViewModels/Device/DevicesListViewModel.cs
+++ b/userinterface/ViewModels/Device/DevicesListViewModel.cs
@@ -11,12 +11,12 @@ namespace userinterface.ViewModels.Device
             DevicesBE = devicesBE;
             DeviceViews = [];
             UpdateDeviceViews();
-            DevicesBE.Devices.CollectionChanged += DevicesCollectionChanged;
+            ((INotifyCollectionChanged)DevicesBE.Elements).CollectionChanged += DevicesCollectionChanged;
         }
 
         protected BE.DevicesModel DevicesBE { get; }
 
-        public ObservableCollection<BE.DeviceModel> Devices => DevicesBE.Devices;
+        public ReadOnlyObservableCollection<BE.IDeviceModel> Devices => DevicesBE.Elements;
 
         public ObservableCollection<DeviceViewModel> DeviceViews { get; }
 
@@ -26,12 +26,12 @@ namespace userinterface.ViewModels.Device
         public void UpdateDeviceViews()
         {
             DeviceViews.Clear();
-            foreach (BE.DeviceModel device in DevicesBE.Devices)
+            foreach (BE.IDeviceModel device in DevicesBE.Elements)
             {
                 DeviceViews.Add(new DeviceViewModel(device, DevicesBE));
             }
         }
 
-        public bool TryAddDevice() => DevicesBE.TryAddDevice();
+        public bool TryAddDevice() => DevicesBE.TryAddNewDefault();
     }
 }

--- a/userinterface/ViewModels/Mapping/MappingViewModel.cs
+++ b/userinterface/ViewModels/Mapping/MappingViewModel.cs
@@ -21,11 +21,11 @@ namespace userinterface.ViewModels.Mapping
 
         public void HandleAddMappingSelection(SelectionChangedEventArgs e)
         {
-            if (e.AddedItems.Count > 0 && e.AddedItems[0] is BE.DeviceGroupModel deviceGroup)
+            if (e.AddedItems.Count > 0 && e.AddedItems[0] is string deviceGroup)
             {
                 // TODO: re-add default profile
-                // MappingBE.TryAddMapping(deviceGroup.ModelValue, BE.ProfilesModel.DefaultProfile.CurrentNameForDisplay);
-                MappingBE.TryAddMapping(deviceGroup.ModelValue, "Default");
+                // MappingBE.TryAddMapping(deviceGroup, BE.ProfilesModel.DefaultProfile.CurrentNameForDisplay);
+                MappingBE.TryAddMapping(deviceGroup, "Default");
             }
         }
 

--- a/userinterface/Views/Device/DeviceGroupSelectorView.axaml
+++ b/userinterface/Views/Device/DeviceGroupSelectorView.axaml
@@ -113,7 +113,7 @@
                   Margin="12,0,0,0">
 			<ComboBox.ItemTemplate>
 				<DataTemplate>
-					<TextBlock Text="{Binding InterfaceValue}" />
+					<TextBlock Text="{Binding}" />
 				</DataTemplate>
 			</ComboBox.ItemTemplate>
 		</ComboBox>

--- a/userinterface/Views/Device/DeviceGroupView.axaml
+++ b/userinterface/Views/Device/DeviceGroupView.axaml
@@ -61,7 +61,7 @@
 
 			<TextBox KeyDown="TextBox_KeyDown"
                      LostFocus="LostFocusHandler"
-                     Text="{Binding DeviceGroupBE.InterfaceValue, Mode=TwoWay}" />
+                     Text="{Binding DeviceGroupBE, Mode=TwoWay}" />
 		</StackPanel>
 	</Border>
 </UserControl>

--- a/userinterface/Views/Device/DeviceGroupView.axaml.cs
+++ b/userinterface/Views/Device/DeviceGroupView.axaml.cs
@@ -31,12 +31,7 @@ public partial class DeviceGroupView : UserControl
 
     public void LostFocusHandler(object sender, RoutedEventArgs args)
     {
-        if (sender is TextBox senderTextBox)
-        {
-            if (senderTextBox.DataContext is BE.DeviceGroupModel deviceGroup)
-            {
-                deviceGroup.TryUpdateFromInterface();
-            }
-        }
+        // Device groups are now simple strings, no longer editable settings
+        // The binding handles updates automatically
     }
 }

--- a/userinterface/Views/Mapping/MappingView.axaml
+++ b/userinterface/Views/Mapping/MappingView.axaml
@@ -155,7 +155,7 @@
 								 BorderThickness="0">
 							<ListBox.ItemTemplate>
 								<DataTemplate>
-									<TextBlock Text="{Binding InterfaceValue}"/>
+									<TextBlock Text="{Binding}"/>
 								</DataTemplate>
 							</ListBox.ItemTemplate>
 						</ListBox>
@@ -173,7 +173,7 @@
 						<TextBlock Grid.Column="0"
 								   HorizontalAlignment="Left"
 								   VerticalAlignment="Center"
-								   Text="{Binding DeviceGroup.InterfaceValue}"/>
+								   Text="{Binding DeviceGroup}"/>
 						<TextBlock Grid.Column="1"
 								   Classes="Arrow"
 								   HorizontalAlignment="Center"

--- a/userinterface/Views/Mapping/MappingView.axaml.cs
+++ b/userinterface/Views/Mapping/MappingView.axaml.cs
@@ -26,7 +26,7 @@ public partial class MappingView : UserControl
         if (e.AddedItems.Count > 0
             && DataContext is MappingViewModel viewModel)
         {
-            DeviceGroupSelectorToAddMapping.ItemsSource = Enumerable.Empty<DeviceGroupModel>();
+            DeviceGroupSelectorToAddMapping.ItemsSource = Enumerable.Empty<string>();
             viewModel.HandleAddMappingSelection(e);
             DeviceGroupSelectorToAddMapping.ItemsSource = viewModel.MappingBE.DeviceGroupsStillUnmapped;
         }

--- a/userspace-backend/BackEnd.cs
+++ b/userspace-backend/BackEnd.cs
@@ -154,11 +154,11 @@ namespace userspace_backend
 
         protected IEnumerable<DeviceSettings> MapToDriverDevices(string dg, string profileName)
         {
-            IEnumerable<DeviceModel> deviceModels = Devices.Elements.Where(d => d.DeviceGroup.ModelValue.Equals(dg));
+            IEnumerable<IDeviceModel> deviceModels = Devices.Elements.Where(d => d.DeviceGroup.ModelValue.Equals(dg));
             return deviceModels.Select(dm => MapToDriverDevice(dm, profileName));
         }
 
-        protected DeviceSettings MapToDriverDevice(DeviceModel deviceModel, string profileName)
+        protected DeviceSettings MapToDriverDevice(IDeviceModel deviceModel, string profileName)
         {
             return new DeviceSettings()
             {

--- a/userspace-backend/BackEnd.cs
+++ b/userspace-backend/BackEnd.cs
@@ -26,12 +26,14 @@ namespace userspace_backend
             IBackEndLoader backEndLoader,
             IProfilesModel profilesModel,
             DevicesModel devicesModel,
-            MappingsModel mappingsModel)
+            MappingsModel mappingsModel,
+            IServiceProvider serviceProvider)
         {
             BackEndLoader = backEndLoader;
             Devices = devicesModel;
             Mappings = mappingsModel;
             Profiles = profilesModel;
+            ServiceProvider = serviceProvider;
         }
 
         public DevicesModel Devices { get; set; }
@@ -42,6 +44,8 @@ namespace userspace_backend
 
         protected IBackEndLoader BackEndLoader { get; set; }
 
+        protected IServiceProvider ServiceProvider { get; set; }
+
         public void Load()
         {
             IEnumerable<DATA.Device> devicesData = BackEndLoader.LoadDevices();
@@ -49,6 +53,9 @@ namespace userspace_backend
 
             IEnumerable<DATA.Profile> profilesData = BackEndLoader.LoadProfiles();
             LoadProfilesFromData(profilesData);
+
+            // Ensure at least one default profile exists
+            EnsureDefaultProfileExists();
 
             DATA.MappingSet mappingData = BackEndLoader.LoadMappings();
             LoadMappingsFromData(mappingData);
@@ -58,7 +65,7 @@ namespace userspace_backend
         {
             foreach(var deviceData in devicesData)
             {
-                Devices.TryAddDevice(deviceData);
+                Devices.TryAddFromData(deviceData);
             }
         }
 
@@ -74,6 +81,22 @@ namespace userspace_backend
             foreach (var mapping in mappingData.Mappings)
             {
                 Mappings.TryAddMapping(mapping);
+            }
+        }
+
+        protected void EnsureDefaultProfileExists()
+        {
+            // If no "Default" profile exists, create one and add it to the beginning
+            if (!Profiles.TryGetElement("Default", out _))
+            {
+                var defaultProfile = ServiceProvider.GetRequiredService<IProfileModel>();
+                defaultProfile.Name.TryUpdateModelDirectly("Default");
+
+                // Access ProfilesModel directly to insert at the beginning
+                if (Profiles is ProfilesModel profilesModel)
+                {
+                    profilesModel.ElementsInternal.Insert(0, defaultProfile);
+                }
             }
         }
 
@@ -94,7 +117,7 @@ namespace userspace_backend
         protected void WriteSettingsToDisk()
         {
             BackEndLoader.WriteSettingsToDisk(
-                Devices.DevicesEnumerable,
+                Devices.Elements,
                 Mappings,
                 Profiles.Elements);
         }
@@ -139,7 +162,7 @@ namespace userspace_backend
 
         protected IEnumerable<DeviceSettings> MapToDriverDevices(string dg, string profileName)
         {
-            IEnumerable<DeviceModel> deviceModels = Devices.Devices.Where(d => d.DeviceGroup.ModelValue.Equals(dg));
+            IEnumerable<DeviceModel> deviceModels = Devices.Elements.Where(d => d.DeviceGroup.ModelValue.Equals(dg));
             return deviceModels.Select(dm => MapToDriverDevice(dm, profileName));
         }
 

--- a/userspace-backend/BackEnd.cs
+++ b/userspace-backend/BackEnd.cs
@@ -95,8 +95,8 @@ namespace userspace_backend
 
         protected void EnsureDefaultDeviceExists()
         {
-            // If no "Default" device exists, create one
-            if (!Devices.TryGetElement("Default", out _))
+            // If no devices exist, create a default device
+            if (Devices.Elements.Count == 0)
             {
                 var defaultDevice = ServiceProvider.GetRequiredService<IDeviceModel>();
                 defaultDevice.Name.TryUpdateModelDirectly("Default");
@@ -110,8 +110,8 @@ namespace userspace_backend
 
         protected void EnsureDefaultProfileExists()
         {
-            // If no "Default" profile exists, create one and add it to the beginning
-            if (!Profiles.TryGetElement("Default", out _))
+            // If no profiles exist, create a default profile
+            if (Profiles.Elements.Count == 0)
             {
                 var defaultProfile = ServiceProvider.GetRequiredService<IProfileModel>();
                 defaultProfile.Name.TryUpdateModelDirectly("Default");
@@ -121,8 +121,8 @@ namespace userspace_backend
 
         protected void EnsureDefaultMappingExists()
         {
-            // If no "Default" mapping exists, create one
-            if (!Mappings.TryGetMapping("Default", out _))
+            // If no mappings exist, create a default mapping
+            if (Mappings.Mappings.Count == 0)
             {
                 var defaultMapping = new DATA.Mapping
                 {

--- a/userspace-backend/BackEnd.cs
+++ b/userspace-backend/BackEnd.cs
@@ -95,21 +95,16 @@ namespace userspace_backend
 
         protected void EnsureDefaultDeviceExists()
         {
-            // If no devices exist, create a hardcoded dummy device for bootstrapping
-            // TODO: Replace with actual device detection via wrapper abstraction (Windows/Linux)
-            if (Devices.Elements.Count == 0)
+            // If no "Default" device exists, create one
+            if (!Devices.TryGetElement("Default", out _))
             {
-                var defaultDevice = new DATA.Device
-                {
-                    Name = "Default Device",
-                    HWID = "DEFAULT_DEVICE_ID",
-                    DPI = 1000,
-                    PollingRate = 1000,
-                    Ignore = false,
-                    DeviceGroup = DeviceGroups.DefaultDeviceGroup
-                };
+                var defaultDevice = ServiceProvider.GetRequiredService<IDeviceModel>();
+                defaultDevice.Name.TryUpdateModelDirectly("Default");
+                defaultDevice.HardwareID.TryUpdateModelDirectly("DEFAULT_DEVICE_ID");
+                defaultDevice.DeviceGroup.TryUpdateModelDirectly(DeviceGroups.DefaultDeviceGroup);
+                // DPI, PollRate, and Ignore already have sensible defaults from DI (1000, 1000, false)
 
-                Devices.TryMapFromData([defaultDevice]);
+                Devices.TryInsert(0, defaultDevice);
             }
         }
 
@@ -126,8 +121,8 @@ namespace userspace_backend
 
         protected void EnsureDefaultMappingExists()
         {
-            // If no mappings exist, create a "Default" mapping
-            if (Mappings.Mappings.Count == 0)
+            // If no "Default" mapping exists, create one
+            if (!Mappings.TryGetMapping("Default", out _))
             {
                 var defaultMapping = new DATA.Mapping
                 {
@@ -146,6 +141,12 @@ namespace userspace_backend
                         mapping.SetActive = true;
                     }
                 }
+            }
+
+            // Ensure at least one mapping has SetActive = true
+            if (Mappings.GetMappingToSetActive() == null && Mappings.Mappings.Count > 0)
+            {
+                Mappings.Mappings[0].SetActive = true;
             }
         }
 

--- a/userspace-backend/BackEnd.cs
+++ b/userspace-backend/BackEnd.cs
@@ -57,7 +57,6 @@ namespace userspace_backend
             DATA.MappingSet mappingData = BackEndLoader.LoadMappings();
             LoadMappingsFromData(mappingData);
 
-            // Ensure defaults exist for first-run experience
             EnsureDefaultDeviceGroupExists();
             EnsureDefaultDeviceExists();
             EnsureDefaultProfileExists();

--- a/userspace-backend/BackEnd.cs
+++ b/userspace-backend/BackEnd.cs
@@ -63,10 +63,7 @@ namespace userspace_backend
 
         protected void LoadDevicesFromData(IEnumerable<DATA.Device> devicesData)
         {
-            foreach(var deviceData in devicesData)
-            {
-                Devices.TryAddFromData(deviceData);
-            }
+            Devices.TryMapFromData(devicesData);
         }
 
         protected void LoadProfilesFromData(IEnumerable<DATA.Profile> profileData)

--- a/userspace-backend/BackEnd.cs
+++ b/userspace-backend/BackEnd.cs
@@ -59,6 +59,7 @@ namespace userspace_backend
 
             // Ensure defaults exist for first-run experience
             EnsureDefaultDeviceGroupExists();
+            EnsureDefaultDeviceExists();
             EnsureDefaultProfileExists();
             EnsureDefaultMappingExists();
         }
@@ -89,6 +90,26 @@ namespace userspace_backend
             if (Devices.DeviceGroups.DeviceGroupModels.Count == 0)
             {
                 Devices.DeviceGroups.AddOrGetDeviceGroup(DeviceGroups.DefaultDeviceGroup);
+            }
+        }
+
+        protected void EnsureDefaultDeviceExists()
+        {
+            // If no devices exist, create a hardcoded dummy device for bootstrapping
+            // TODO: Replace with actual device detection via wrapper abstraction (Windows/Linux)
+            if (Devices.Elements.Count == 0)
+            {
+                var defaultDevice = new DATA.Device
+                {
+                    Name = "Default Device",
+                    HWID = "DEFAULT_DEVICE_ID",
+                    DPI = 1000,
+                    PollingRate = 1000,
+                    Ignore = false,
+                    DeviceGroup = DeviceGroups.DefaultDeviceGroup
+                };
+
+                Devices.TryMapFromData([defaultDevice]);
             }
         }
 

--- a/userspace-backend/BackEnd.cs
+++ b/userspace-backend/BackEnd.cs
@@ -88,12 +88,7 @@ namespace userspace_backend
             {
                 var defaultProfile = ServiceProvider.GetRequiredService<IProfileModel>();
                 defaultProfile.Name.TryUpdateModelDirectly("Default");
-
-                // Access ProfilesModel directly to insert at the beginning
-                if (Profiles is ProfilesModel profilesModel)
-                {
-                    profilesModel.ElementsInternal.Insert(0, defaultProfile);
-                }
+                Profiles.TryInsert(0, defaultProfile);
             }
         }
 

--- a/userspace-backend/BackEnd.cs
+++ b/userspace-backend/BackEnd.cs
@@ -54,11 +54,13 @@ namespace userspace_backend
             IEnumerable<DATA.Profile> profilesData = BackEndLoader.LoadProfiles();
             LoadProfilesFromData(profilesData);
 
-            // Ensure at least one default profile exists
-            EnsureDefaultProfileExists();
-
             DATA.MappingSet mappingData = BackEndLoader.LoadMappings();
             LoadMappingsFromData(mappingData);
+
+            // Ensure defaults exist for first-run experience
+            EnsureDefaultDeviceGroupExists();
+            EnsureDefaultProfileExists();
+            EnsureDefaultMappingExists();
         }
 
         protected void LoadDevicesFromData(IEnumerable<DATA.Device> devicesData)
@@ -81,6 +83,15 @@ namespace userspace_backend
             }
         }
 
+        protected void EnsureDefaultDeviceGroupExists()
+        {
+            // If no device groups exist, create a "Default" group
+            if (Devices.DeviceGroups.DeviceGroupModels.Count == 0)
+            {
+                Devices.DeviceGroups.AddOrGetDeviceGroup(DeviceGroups.DefaultDeviceGroup);
+            }
+        }
+
         protected void EnsureDefaultProfileExists()
         {
             // If no "Default" profile exists, create one and add it to the beginning
@@ -89,6 +100,31 @@ namespace userspace_backend
                 var defaultProfile = ServiceProvider.GetRequiredService<IProfileModel>();
                 defaultProfile.Name.TryUpdateModelDirectly("Default");
                 Profiles.TryInsert(0, defaultProfile);
+            }
+        }
+
+        protected void EnsureDefaultMappingExists()
+        {
+            // If no mappings exist, create a "Default" mapping
+            if (Mappings.Mappings.Count == 0)
+            {
+                var defaultMapping = new DATA.Mapping
+                {
+                    Name = "Default",
+                    GroupsToProfiles = new DATA.Mapping.GroupsToProfilesMapping
+                    {
+                        { DeviceGroups.DefaultDeviceGroup, "Default" }
+                    }
+                };
+
+                if (Mappings.TryAddMapping(defaultMapping))
+                {
+                    // Set this as the active mapping
+                    if (Mappings.TryGetMapping("Default", out MappingModel? mapping) && mapping != null)
+                    {
+                        mapping.SetActive = true;
+                    }
+                }
             }
         }
 

--- a/userspace-backend/BackEnd.cs
+++ b/userspace-backend/BackEnd.cs
@@ -20,18 +20,17 @@ namespace userspace_backend
         IProfilesModel Profiles { get; }
     }
 
-    public class BackEnd
+    public class BackEnd : IBackEnd
     {
         public BackEnd(
             IBackEndLoader backEndLoader,
-            IProfilesModel profilesModel)
+            IProfilesModel profilesModel,
+            DevicesModel devicesModel,
+            MappingsModel mappingsModel)
         {
-            // TODO: fully construct BackEnd via DI
-            ServiceCollection services = new ServiceCollection();
-            IServiceProvider serviceProvider = BackEndComposer.Compose(services);
-
             BackEndLoader = backEndLoader;
-            Devices = new DevicesModel(serviceProvider.GetRequiredService<ISystemDevicesProvider>());
+            Devices = devicesModel;
+            Mappings = mappingsModel;
             Profiles = profilesModel;
         }
 
@@ -45,14 +44,14 @@ namespace userspace_backend
 
         public void Load()
         {
-            IEnumerable<DATA.Device> devicesData = BackEndLoader.LoadDevices(); ;
+            IEnumerable<DATA.Device> devicesData = BackEndLoader.LoadDevices();
             LoadDevicesFromData(devicesData);
 
-            IEnumerable<DATA.Profile> profilesData = BackEndLoader.LoadProfiles(); ;
+            IEnumerable<DATA.Profile> profilesData = BackEndLoader.LoadProfiles();
             LoadProfilesFromData(profilesData);
 
             DATA.MappingSet mappingData = BackEndLoader.LoadMappings();
-            Mappings = new MappingsModel(mappingData, Devices.DeviceGroups, Profiles);
+            LoadMappingsFromData(mappingData);
         }
 
         protected void LoadDevicesFromData(IEnumerable<DATA.Device> devicesData)
@@ -66,6 +65,16 @@ namespace userspace_backend
         protected void LoadProfilesFromData(IEnumerable<DATA.Profile> profileData)
         {
             Profiles.TryMapFromData(profileData);
+        }
+
+        protected void LoadMappingsFromData(DATA.MappingSet mappingData)
+        {
+            // Clear existing mappings and reload from data
+            Mappings.Mappings.Clear();
+            foreach (var mapping in mappingData.Mappings)
+            {
+                Mappings.TryAddMapping(mapping);
+            }
         }
 
         public void Apply()

--- a/userspace-backend/BackEndComposer.cs
+++ b/userspace-backend/BackEndComposer.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
+using userspace_backend.Display;
 using userspace_backend.IO;
 using userspace_backend.Model;
 using userspace_backend.Model.AccelDefinitions;
@@ -434,6 +435,12 @@ namespace userspace_backend
                         validator: services.GetRequiredService<IModelValueValidator<double>>()));
 
             #endregion Profile
+
+            #region Display
+
+            services.AddTransient<ICurvePreview, CurvePreview>();
+
+            #endregion Display
 
             #region DeviceGroup
 

--- a/userspace-backend/BackEndComposer.cs
+++ b/userspace-backend/BackEndComposer.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
+using DATA = userspace_backend.Data;
 using userspace_backend.Display;
 using userspace_backend.IO;
 using userspace_backend.Model;
@@ -515,6 +516,21 @@ namespace userspace_backend
 
             #region Mapping
 
+            services.AddSingleton<MappingsModel>(sp =>
+            {
+                // Initialize with empty MappingSet - will be populated during BackEnd.Load()
+                var deviceGroups = sp.GetRequiredService<DeviceGroups>();
+                var profiles = sp.GetRequiredService<IProfilesModel>();
+                var emptyMappingSet = new DATA.MappingSet { Mappings = [] };
+                return new MappingsModel(emptyMappingSet, deviceGroups, profiles);
+            });
+
+            services.AddSingleton<MappingNameValidator>(sp =>
+            {
+                var mappings = sp.GetRequiredService<MappingsModel>();
+                return new MappingNameValidator(mappings);
+            });
+
             services.AddTransient<IMappingModel, MappingModel>();
             services.AddKeyedTransient<IEditableSettingSpecific<string>>(
                 MappingModel.NameDIKey, (IServiceProvider services, object? key) =>
@@ -522,7 +538,7 @@ namespace userspace_backend
                         displayName: "Name",
                         initialValue: "name",
                         parser: services.GetRequiredService<IUserInputParser<string>>(),
-                        validator: services.GetRequiredKeyedService<IModelValueValidator<string>>(MappingModel.NameDIKey)));
+                        validator: services.GetRequiredService<MappingNameValidator>()));
 
             #endregion Mapping
 

--- a/userspace-backend/BackEndComposer.cs
+++ b/userspace-backend/BackEndComposer.cs
@@ -11,6 +11,7 @@ using userspace_backend.Model.ProfileComponents;
 using static userspace_backend.Data.Profiles.Accel.FormulaAccel;
 using static userspace_backend.Data.Profiles.Accel.LookupTableAccel;
 using static userspace_backend.Data.Profiles.Acceleration;
+using static userspace_backend.Model.EditableSettings.EditableSettingsSelectorHelper;
 
 namespace userspace_backend
 {
@@ -180,6 +181,17 @@ namespace userspace_backend
                         parser: services.GetRequiredService<IUserInputParser<AccelerationDefinitionType>>(),
                         validator: services.GetRequiredService<IModelValueValidator<AccelerationDefinitionType>>()));
 
+            // Register selector options for AccelerationDefinitionType
+            services.AddKeyedTransient<IEditableSettingsCollectionSpecific<userspace_backend.Data.Profiles.Acceleration>>(
+                GetSelectionKey(AccelerationDefinitionType.None),
+                (sp, key) => (IEditableSettingsCollectionSpecific<userspace_backend.Data.Profiles.Acceleration>)sp.GetRequiredService<INoAccelDefinitionModel>());
+            services.AddKeyedTransient<IEditableSettingsCollectionSpecific<userspace_backend.Data.Profiles.Acceleration>>(
+                GetSelectionKey(AccelerationDefinitionType.Formula),
+                (sp, key) => (IEditableSettingsCollectionSpecific<userspace_backend.Data.Profiles.Acceleration>)sp.GetRequiredService<IFormulaAccelModel>());
+            services.AddKeyedTransient<IEditableSettingsCollectionSpecific<userspace_backend.Data.Profiles.Acceleration>>(
+                GetSelectionKey(AccelerationDefinitionType.LookupTable),
+                (sp, key) => (IEditableSettingsCollectionSpecific<userspace_backend.Data.Profiles.Acceleration>)sp.GetRequiredService<ILookupTableDefinitionModel>());
+
             #endregion Acceleration
 
             #region FormulaAccel
@@ -200,6 +212,26 @@ namespace userspace_backend
                         initialValue: false,
                         parser: services.GetRequiredService<IUserInputParser<bool>>(),
                         validator: services.GetRequiredService<IModelValueValidator<bool>>()));
+
+            // Register selector options for AccelerationFormulaType
+            services.AddKeyedTransient<IEditableSettingsCollectionSpecific<userspace_backend.Data.Profiles.Accel.FormulaAccel>>(
+                GetSelectionKey(AccelerationFormulaType.Synchronous),
+                (sp, key) => (IEditableSettingsCollectionSpecific<userspace_backend.Data.Profiles.Accel.FormulaAccel>)sp.GetRequiredService<ISynchronousAccelerationDefinitionModel>());
+            services.AddKeyedTransient<IEditableSettingsCollectionSpecific<userspace_backend.Data.Profiles.Accel.FormulaAccel>>(
+                GetSelectionKey(AccelerationFormulaType.Linear),
+                (sp, key) => (IEditableSettingsCollectionSpecific<userspace_backend.Data.Profiles.Accel.FormulaAccel>)sp.GetRequiredService<ILinearAccelerationDefinitionModel>());
+            services.AddKeyedTransient<IEditableSettingsCollectionSpecific<userspace_backend.Data.Profiles.Accel.FormulaAccel>>(
+                GetSelectionKey(AccelerationFormulaType.Classic),
+                (sp, key) => (IEditableSettingsCollectionSpecific<userspace_backend.Data.Profiles.Accel.FormulaAccel>)sp.GetRequiredService<IClassicAccelerationDefinitionModel>());
+            services.AddKeyedTransient<IEditableSettingsCollectionSpecific<userspace_backend.Data.Profiles.Accel.FormulaAccel>>(
+                GetSelectionKey(AccelerationFormulaType.Power),
+                (sp, key) => (IEditableSettingsCollectionSpecific<userspace_backend.Data.Profiles.Accel.FormulaAccel>)sp.GetRequiredService<IPowerAccelerationDefinitionModel>());
+            services.AddKeyedTransient<IEditableSettingsCollectionSpecific<userspace_backend.Data.Profiles.Accel.FormulaAccel>>(
+                GetSelectionKey(AccelerationFormulaType.Natural),
+                (sp, key) => (IEditableSettingsCollectionSpecific<userspace_backend.Data.Profiles.Accel.FormulaAccel>)sp.GetRequiredService<INaturalAccelerationDefinitionModel>());
+            services.AddKeyedTransient<IEditableSettingsCollectionSpecific<userspace_backend.Data.Profiles.Accel.FormulaAccel>>(
+                GetSelectionKey(AccelerationFormulaType.Jump),
+                (sp, key) => (IEditableSettingsCollectionSpecific<userspace_backend.Data.Profiles.Accel.FormulaAccel>)sp.GetRequiredService<IJumpAccelerationDefinitionModel>());
 
             #endregion FormulaAccel
 

--- a/userspace-backend/BackEndComposer.cs
+++ b/userspace-backend/BackEndComposer.cs
@@ -550,6 +550,14 @@ namespace userspace_backend
 
             #endregion IO Layer
 
+            #region BackEnd
+
+            services.AddSingleton<IProfilesModel, ProfilesModel>();
+
+            services.AddSingleton<IBackEnd, BackEnd>();
+
+            #endregion BackEnd
+
             return services.BuildServiceProvider();
         }
     }

--- a/userspace-backend/BackEndComposer.cs
+++ b/userspace-backend/BackEndComposer.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
+using userspace_backend.IO;
 using userspace_backend.Model;
 using userspace_backend.Model.AccelDefinitions;
 using userspace_backend.Model.AccelDefinitions.Formula;
@@ -494,6 +495,14 @@ namespace userspace_backend
                         validator: services.GetRequiredKeyedService<IModelValueValidator<string>>(MappingModel.NameDIKey)));
 
             #endregion Mapping
+
+            #region IO Layer
+
+            services.AddSingleton<DevicesReaderWriter>();
+            services.AddSingleton<MappingsReaderWriter>();
+            services.AddSingleton<ProfileReaderWriter>();
+
+            #endregion IO Layer
 
             return services.BuildServiceProvider();
         }

--- a/userspace-backend/BackEndComposer.cs
+++ b/userspace-backend/BackEndComposer.cs
@@ -47,6 +47,9 @@ namespace userspace_backend
             services.AddKeyedSingleton<IModelValueValidator<string>, DefaultModelValueValidator<string>>(
                 DefaultModelValueValidator<string>.AllChangeInvalidDIKey);
 
+            services.AddKeyedSingleton<IModelValueValidator<string>, MaxNameLengthValidator>(
+                ProfileModel.NameDIKey);
+
             #endregion Validators
 
             #region Hidden
@@ -417,8 +420,7 @@ namespace userspace_backend
                         displayName: "Name",
                         "Empty",
                         parser: services.GetRequiredService<IUserInputParser<string>>(),
-                        // TODO: DI - change to max name length validator
-                        validator: services.GetRequiredService<IModelValueValidator<string>>()));
+                        validator: services.GetRequiredKeyedService<IModelValueValidator<string>>(ProfileModel.NameDIKey)));
             services.AddKeyedTransient<IEditableSettingSpecific<int>>(
                 ProfileModel.OutputDPIDIKey, (IServiceProvider services, object? key) =>
                     new EditableSettingV2<int>(

--- a/userspace-backend/BackEndComposer.cs
+++ b/userspace-backend/BackEndComposer.cs
@@ -522,7 +522,7 @@ namespace userspace_backend
                 var deviceGroups = sp.GetRequiredService<DeviceGroups>();
                 var profiles = sp.GetRequiredService<IProfilesModel>();
                 var emptyMappingSet = new DATA.MappingSet { Mappings = [] };
-                return new MappingsModel(emptyMappingSet, deviceGroups, profiles);
+                return new MappingsModel(emptyMappingSet, deviceGroups, profiles, sp);
             });
 
             services.AddSingleton<MappingNameValidator>(sp =>

--- a/userspace-backend/BackEndComposer.cs
+++ b/userspace-backend/BackEndComposer.cs
@@ -446,6 +446,27 @@ namespace userspace_backend
 
             #region DeviceGroup
 
+            services.AddSingleton<DeviceGroups>(sp =>
+            {
+                // Initialize with empty collection - will be populated during BackEnd.Load()
+                return new DeviceGroups([]);
+            });
+
+            services.AddSingleton<DeviceGroupValidator>(sp =>
+            {
+                var deviceGroups = sp.GetRequiredService<DeviceGroups>();
+                return new DeviceGroupValidator(deviceGroups);
+            });
+
+            services.AddSingleton<DevicesModel>(sp =>
+            {
+                var systemDevicesProvider = sp.GetRequiredService<ISystemDevicesProvider>();
+                var deviceGroups = sp.GetRequiredService<DeviceGroups>();
+                var devicesModel = new DevicesModel(sp, systemDevicesProvider);
+                devicesModel.DeviceGroups = deviceGroups;
+                return devicesModel;
+            });
+
             services.AddTransient<IDeviceModel, DeviceModel>();
             services.AddKeyedTransient<IEditableSettingSpecific<string>>(
                 DeviceModel.NameDIKey, (IServiceProvider services, object? key) =>

--- a/userspace-backend/BackEndLoader.cs
+++ b/userspace-backend/BackEndLoader.cs
@@ -19,7 +19,7 @@ namespace userspace_backend
         public IEnumerable<DATA.Profile> LoadProfiles();
 
         public void WriteSettingsToDisk(
-            IEnumerable<DeviceModel> devices,
+            IEnumerable<IDeviceModel> devices,
             MappingsModel mappings,
             IEnumerable<IProfileModel> profiles);
     }
@@ -62,7 +62,7 @@ namespace userspace_backend
         }
 
         public void WriteSettingsToDisk(
-            IEnumerable<DeviceModel> devices,
+            IEnumerable<IDeviceModel> devices,
             MappingsModel mappings,
             IEnumerable<IProfileModel> profiles)
         {
@@ -71,7 +71,7 @@ namespace userspace_backend
             WriteProfiles(profiles);
         }
 
-        protected void WriteDevices(IEnumerable<DeviceModel> devices)
+        protected void WriteDevices(IEnumerable<IDeviceModel> devices)
         {
             IEnumerable<DATA.Device> devicesData = devices.Select(d => d.MapToData());
             string devicesFileText = DevicesReaderWriter.Serialize(devicesData);

--- a/userspace-backend/BackEndLoader.cs
+++ b/userspace-backend/BackEndLoader.cs
@@ -46,6 +46,10 @@ namespace userspace_backend
         public IEnumerable<DATA.Device> LoadDevices()
         {
             string devicesFile = GetDevicesFile(SettingsDirectory);
+            if (!File.Exists(devicesFile))
+            {
+                return [];
+            }
             string devicesText = File.ReadAllText(devicesFile);
             IEnumerable<DATA.Device> devicesData = DevicesReaderWriter.Read(devicesText);
             return devicesData;
@@ -53,12 +57,39 @@ namespace userspace_backend
 
         public DATA.MappingSet LoadMappings()
         {
-            throw new NotImplementedException();
+            string mappingsFile = GetMappingsFile(SettingsDirectory);
+            if (!File.Exists(mappingsFile))
+            {
+                return new DATA.MappingSet { Mappings = [] };
+            }
+            string mappingsText = File.ReadAllText(mappingsFile);
+            DATA.MappingSet mappingsData = MappingsReaderWriter.Read(mappingsText);
+            return mappingsData;
         }
 
         public IEnumerable<DATA.Profile> LoadProfiles()
         {
-            throw new NotImplementedException();
+            string profilesDirectory = GetProfilesDirectory(SettingsDirectory);
+            if (!Directory.Exists(profilesDirectory))
+            {
+                return [];
+            }
+
+            string[] profileFiles = Directory.GetFiles(profilesDirectory, "*.json");
+            if (profileFiles.Length == 0)
+            {
+                return [];
+            }
+
+            List<DATA.Profile> profiles = [];
+            foreach (string profileFile in profileFiles)
+            {
+                string profileText = File.ReadAllText(profileFile);
+                DATA.Profile profileData = ProfileReaderWriter.Read(profileText);
+                profiles.Add(profileData);
+            }
+
+            return profiles;
         }
 
         public void WriteSettingsToDisk(

--- a/userspace-backend/BackEndLoader.cs
+++ b/userspace-backend/BackEndLoader.cs
@@ -26,18 +26,22 @@ namespace userspace_backend
 
     public class BackEndLoader : IBackEndLoader
     {
-        public static DevicesReaderWriter DevicesReaderWriter = new DevicesReaderWriter();
-
-        public static MappingsReaderWriter MappingsReaderWriter = new MappingsReaderWriter();
-
-        public static ProfileReaderWriter ProfileReaderWriter = new ProfileReaderWriter();
-
-        public BackEndLoader(string settingsDirectory)
+        public BackEndLoader(
+            string settingsDirectory,
+            DevicesReaderWriter devicesReaderWriter,
+            MappingsReaderWriter mappingsReaderWriter,
+            ProfileReaderWriter profileReaderWriter)
         {
             SettingsDirectory = settingsDirectory;
+            DevicesReaderWriter = devicesReaderWriter;
+            MappingsReaderWriter = mappingsReaderWriter;
+            ProfileReaderWriter = profileReaderWriter;
         }
 
         public string SettingsDirectory { get; private set; }
+        protected DevicesReaderWriter DevicesReaderWriter { get; }
+        protected MappingsReaderWriter MappingsReaderWriter { get; }
+        protected ProfileReaderWriter ProfileReaderWriter { get; }
 
         public IEnumerable<DATA.Device> LoadDevices()
         {

--- a/userspace-backend/BackEndLoader.cs
+++ b/userspace-backend/BackEndLoader.cs
@@ -51,7 +51,7 @@ namespace userspace_backend
                 return [];
             }
             string devicesText = File.ReadAllText(devicesFile);
-            IEnumerable<DATA.Device> devicesData = DevicesReaderWriter.Read(devicesText);
+            IEnumerable<DATA.Device> devicesData = DevicesReaderWriter.Deserialize(devicesText);
             return devicesData;
         }
 
@@ -63,7 +63,7 @@ namespace userspace_backend
                 return new DATA.MappingSet { Mappings = [] };
             }
             string mappingsText = File.ReadAllText(mappingsFile);
-            DATA.MappingSet mappingsData = MappingsReaderWriter.Read(mappingsText);
+            DATA.MappingSet mappingsData = MappingsReaderWriter.Deserialize(mappingsText);
             return mappingsData;
         }
 
@@ -76,16 +76,11 @@ namespace userspace_backend
             }
 
             string[] profileFiles = Directory.GetFiles(profilesDirectory, "*.json");
-            if (profileFiles.Length == 0)
-            {
-                return [];
-            }
-
             List<DATA.Profile> profiles = [];
             foreach (string profileFile in profileFiles)
             {
                 string profileText = File.ReadAllText(profileFile);
-                DATA.Profile profileData = ProfileReaderWriter.Read(profileText);
+                DATA.Profile profileData = ProfileReaderWriter.Deserialize(profileText);
                 profiles.Add(profileData);
             }
 

--- a/userspace-backend/Bootstrapper.cs
+++ b/userspace-backend/Bootstrapper.cs
@@ -35,7 +35,7 @@ namespace userspace_backend
             return ProfilesToLoad;
         }
 
-        public void WriteSettingsToDisk(IEnumerable<DeviceModel> devices, MappingsModel mappings, IEnumerable<IProfileModel> profiles)
+        public void WriteSettingsToDisk(IEnumerable<IDeviceModel> devices, MappingsModel mappings, IEnumerable<IProfileModel> profiles)
         {
             BackEndLoader.WriteSettingsToDisk(devices, mappings, profiles);
         }

--- a/userspace-backend/IO/DevicesReaderWriter.cs
+++ b/userspace-backend/IO/DevicesReaderWriter.cs
@@ -19,7 +19,7 @@ namespace userspace_backend.IO
 
         public override IEnumerable<Device> Deserialize(string toRead)
         {
-            return JsonSerializer.Deserialize<List<Device>>(toRead);
+            return JsonSerializer.Deserialize<List<Device>>(toRead, JsonOptions);
         }
     }
 }

--- a/userspace-backend/IO/MappingsReaderWriter.cs
+++ b/userspace-backend/IO/MappingsReaderWriter.cs
@@ -25,7 +25,7 @@ namespace userspace_backend.IO
 
         public override MappingSet Deserialize(string toRead)
         {
-            return JsonSerializer.Deserialize<MappingSet>(toRead);
+            return JsonSerializer.Deserialize<MappingSet>(toRead, JsonOptions);
         }
     }
 }

--- a/userspace-backend/IO/ProfileReaderWriter.cs
+++ b/userspace-backend/IO/ProfileReaderWriter.cs
@@ -20,7 +20,7 @@ namespace userspace_backend.IO
 
         public override DATA.Profile Deserialize(string toRead)
         {
-            return JsonSerializer.Deserialize<DATA.Profile>(toRead);
+            return JsonSerializer.Deserialize<DATA.Profile>(toRead, JsonOptions);
         }
 
         public override string Serialize(DATA.Profile toWrite)

--- a/userspace-backend/Model/DeviceGroups.cs
+++ b/userspace-backend/Model/DeviceGroups.cs
@@ -9,13 +9,12 @@ namespace userspace_backend.Model
 {
     public interface IDeviceGroups
     {
-
+        bool TryGetDeviceGroup(string name, out string? deviceGroup);
     }
 
     public class DeviceGroups : EditableSettingsCollection<IEnumerable<string>>
     {
-        public static readonly DeviceGroupModel DefaultDeviceGroup =
-            new DeviceGroupModel("Default", ModelValueValidators.AllChangesInvalidStringValidator);
+        public const string DefaultDeviceGroup = "Default";
 
         public DeviceGroups(IEnumerable<string> devices)
             : base(devices)
@@ -23,23 +22,23 @@ namespace userspace_backend.Model
             GroupNameChangeValidator = new DeviceGroupValidator(this);
         }
 
-        public ObservableCollection<DeviceGroupModel> DeviceGroupModels { get; set; }
+        public ObservableCollection<string> DeviceGroupModels { get; set; }
 
         protected DeviceGroupValidator GroupNameChangeValidator { get; set; }
 
-        public bool TryGetDeviceGroup(string name, out DeviceGroupModel? deviceGroup)
+        public bool TryGetDeviceGroup(string name, out string? deviceGroup)
         {
             deviceGroup = DeviceGroupModels.FirstOrDefault(
-                g => string.Equals(g.ModelValue, name, StringComparison.InvariantCultureIgnoreCase));
+                g => string.Equals(g, name, StringComparison.InvariantCultureIgnoreCase));
 
             return deviceGroup is not null;
         }
 
-        public DeviceGroupModel AddOrGetDeviceGroup(string deviceGroupName)
+        public string AddOrGetDeviceGroup(string deviceGroupName)
         {
-            if (!TryGetDeviceGroup(deviceGroupName, out DeviceGroupModel? deviceGroup))
+            if (!TryGetDeviceGroup(deviceGroupName, out string? deviceGroup))
             {
-                deviceGroup = new DeviceGroupModel(deviceGroupName, GroupNameChangeValidator);
+                deviceGroup = deviceGroupName;
                 DeviceGroupModels.Add(deviceGroup);
             }
 
@@ -80,24 +79,23 @@ namespace userspace_backend.Model
                 return false;
             }
 
-            DeviceGroupModel deviceGroup = new DeviceGroupModel(deviceGroupName, GroupNameChangeValidator);
-            DeviceGroupModels.Add(deviceGroup);
+            DeviceGroupModels.Add(deviceGroupName);
             return true;
         }
 
-        public bool RemoveDeviceGroup(DeviceGroupModel deviceGroup)
+        public bool RemoveDeviceGroup(string deviceGroup)
         {
             return DeviceGroupModels.Remove(deviceGroup);
         }
 
         public override IEnumerable<string> MapToData()
         {
-            return DeviceGroupModels.Select(g => g.ModelValue);
+            return DeviceGroupModels;
         }
 
         protected override IEnumerable<IEditableSetting> EnumerateEditableSettings()
         {
-            return DeviceGroupModels;
+            return [];
         }
 
         protected override IEnumerable<IEditableSettingsCollectionV2> EnumerateEditableSettingsCollections()
@@ -109,7 +107,7 @@ namespace userspace_backend.Model
         {
             // This initialization does not set up all device group models.
             // That is done in backend construction in order to point the devices to their groups.
-            DeviceGroupModels = new ObservableCollection<DeviceGroupModel>() { DefaultDeviceGroup };
+            DeviceGroupModels = new ObservableCollection<string>() { DefaultDeviceGroup };
         }
     }
 

--- a/userspace-backend/Model/DeviceGroups.cs
+++ b/userspace-backend/Model/DeviceGroups.cs
@@ -12,7 +12,7 @@ namespace userspace_backend.Model
         bool TryGetDeviceGroup(string name, out string? deviceGroup);
     }
 
-    public class DeviceGroups : EditableSettingsCollection<IEnumerable<string>>
+    public class DeviceGroups : EditableSettingsCollection<IEnumerable<string>>, IDeviceGroups
     {
         public const string DefaultDeviceGroup = "Default";
 

--- a/userspace-backend/Model/DeviceModel.cs
+++ b/userspace-backend/Model/DeviceModel.cs
@@ -1,4 +1,5 @@
-﻿using userspace_backend.Data;
+﻿using Microsoft.Extensions.DependencyInjection;
+using userspace_backend.Data;
 using userspace_backend.Model.EditableSettings;
 
 namespace userspace_backend.Model
@@ -28,12 +29,12 @@ namespace userspace_backend.Model
         public const string DeviceGroupDIKey = $"{nameof(DeviceModel)}.{nameof(DeviceGroup)}";
 
         public DeviceModel(
-            IEditableSettingSpecific<string> name,
-            IEditableSettingSpecific<string> hardwareID,
-            IEditableSettingSpecific<int> dpi,
-            IEditableSettingSpecific<int> pollRate,
-            IEditableSettingSpecific<bool> ignore,
-            IEditableSettingSpecific<string> deviceGroup)
+            [FromKeyedServices(NameDIKey)] IEditableSettingSpecific<string> name,
+            [FromKeyedServices(HardwareIDDIKey)] IEditableSettingSpecific<string> hardwareID,
+            [FromKeyedServices(DPIDIKey)] IEditableSettingSpecific<int> dpi,
+            [FromKeyedServices(PollRateDIKey)] IEditableSettingSpecific<int> pollRate,
+            [FromKeyedServices(IgnoreDIKey)] IEditableSettingSpecific<bool> ignore,
+            [FromKeyedServices(DeviceGroupDIKey)] IEditableSettingSpecific<string> deviceGroup)
             : base(name, [hardwareID, dpi, pollRate, ignore, deviceGroup], [])
         {
             HardwareID = hardwareID;

--- a/userspace-backend/Model/EditableSettings/EditableSettingsList.cs
+++ b/userspace-backend/Model/EditableSettings/EditableSettingsList.cs
@@ -15,6 +15,8 @@ namespace userspace_backend.Model.EditableSettings
 
         public bool TryAdd(T element);
 
+        public bool TryInsert(int index, T element);
+
         public bool TryGetElement(string name, out T? element);
 
         public bool TryRemoveElement(T element);
@@ -54,6 +56,19 @@ namespace userspace_backend.Model.EditableSettings
             if (!ContainsElementWithName(name))
             {
                 AddElement(element);
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool TryInsert(int index, T element)
+        {
+            string name = GetNameFromElement(element);
+
+            if (!ContainsElementWithName(name))
+            {
+                ElementsInternal.Insert(index, element);
                 return true;
             }
 

--- a/userspace-backend/Model/EditableSettings/MaxNameLengthValidator.cs
+++ b/userspace-backend/Model/EditableSettings/MaxNameLengthValidator.cs
@@ -1,0 +1,24 @@
+namespace userspace_backend.Model.EditableSettings
+{
+    public class MaxNameLengthValidator : IModelValueValidator<string>
+    {
+        public const int MaxNameLength = 100;
+
+        public MaxNameLengthValidator()
+        {
+            MaxLength = MaxNameLength;
+        }
+
+        public MaxNameLengthValidator(int maxLength)
+        {
+            MaxLength = maxLength;
+        }
+
+        public int MaxLength { get; }
+
+        public bool Validate(string value)
+        {
+            return !string.IsNullOrEmpty(value) && value.Length <= MaxLength;
+        }
+    }
+}

--- a/userspace-backend/Model/EditableSettings/MaxNameLengthValidator.cs
+++ b/userspace-backend/Model/EditableSettings/MaxNameLengthValidator.cs
@@ -2,7 +2,7 @@ namespace userspace_backend.Model.EditableSettings
 {
     public class MaxNameLengthValidator : IModelValueValidator<string>
     {
-        public const int MaxNameLength = 100;
+        public const int MaxNameLength = 256;
 
         public MaxNameLengthValidator()
         {

--- a/userspace-backend/Model/MappingModel.cs
+++ b/userspace-backend/Model/MappingModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.ObjectModel;
 using System.Linq;
 using userspace_backend.Model.EditableSettings;
 using userspace_backend.Data;
@@ -18,16 +19,36 @@ namespace userspace_backend.Model
             IEditableSettingSpecific<string> name,
             IModelValueValidator<string> nameValidator,
             IDeviceGroups deviceGroups,
-            IProfilesModel profiles)
+            IProfilesModel profiles,
+            Mapping dataObject)
             : base(name, [], [])
         {
             NameValidator = nameValidator;
             SetActive = true;
             DeviceGroups = deviceGroups;
             Profiles = profiles;
+
+            // Initialize collections
+            IndividualMappings = new ObservableCollection<MappingGroup>();
+            DeviceGroupsStillUnmapped = new ObservableCollection<string>();
+
+            // Initialize mappings from data
+            InitIndividualMappings(dataObject);
+            FindDeviceGroupsStillUnmapped();
+
+            // Wire up events
+            IndividualMappings.CollectionChanged += OnIndividualMappingsChanged;
+            if (DeviceGroups is DeviceGroups dg)
+            {
+                dg.DeviceGroupModels.CollectionChanged += OnIndividualMappingsChanged;
+            }
         }
 
         public bool SetActive { get; set; }
+
+        public ObservableCollection<MappingGroup> IndividualMappings { get; protected set; }
+
+        public ObservableCollection<string> DeviceGroupsStillUnmapped { get; protected set; }
 
         protected IModelValueValidator<string> NameValidator { get; }
 
@@ -45,7 +66,7 @@ namespace userspace_backend.Model
 
             foreach (var group in IndividualMappings)
             {
-                mapping.GroupsToProfiles.Add(group.DeviceGroup.ModelValue, group.Profile.Name.ModelValue);
+                mapping.GroupsToProfiles.Add(group.DeviceGroup, group.Profile.Name.ModelValue);
             }
 
             return mapping;
@@ -61,9 +82,9 @@ namespace userspace_backend.Model
 
         public bool TryAddMapping(string deviceGroupName, string profileName)
         {
-            if (!DeviceGroups.TryGetDeviceGroup(deviceGroupName, out DeviceGroupModel? deviceGroup)
+            if (!DeviceGroups.TryGetDeviceGroup(deviceGroupName, out string? deviceGroup)
                 || deviceGroup == null
-                || IndividualMappings.Any(m => m.DeviceGroup.Equals(deviceGroup)))
+                || IndividualMappings.Any(m => string.Equals(m.DeviceGroup, deviceGroup, StringComparison.InvariantCultureIgnoreCase)))
             {
                 return false;
             }
@@ -89,11 +110,14 @@ namespace userspace_backend.Model
         {
             DeviceGroupsStillUnmapped.Clear();
 
-            foreach (DeviceGroupModel group in DeviceGroups.DeviceGroupModels)
+            if (DeviceGroups is DeviceGroups dg)
             {
-                if (!IndividualMappings.Any(m => m.DeviceGroup.Equals(group)))
+                foreach (string group in dg.DeviceGroupModels)
                 {
-                    DeviceGroupsStillUnmapped.Add(group);
+                    if (!IndividualMappings.Any(m => string.Equals(m.DeviceGroup, group, StringComparison.InvariantCultureIgnoreCase)))
+                    {
+                        DeviceGroupsStillUnmapped.Add(group);
+                    }
                 }
             }
         }
@@ -116,7 +140,7 @@ namespace userspace_backend.Model
 
     public class MappingGroup
     {
-        public DeviceGroupModel DeviceGroup { get; set; }
+        public string DeviceGroup { get; set; }
 
         public IProfileModel Profile { get; set; }
 

--- a/userspace-backend/Model/MappingsModel.cs
+++ b/userspace-backend/Model/MappingsModel.cs
@@ -10,9 +10,10 @@ namespace userspace_backend.Model
 {
     public class MappingsModel : EditableSettingsCollection<DATA.MappingSet>
     {
-        public MappingsModel(DATA.MappingSet dataObject, DeviceGroups deviceGroups, IProfilesModel profiles)
+        public MappingsModel(DATA.MappingSet dataObject, DeviceGroups deviceGroups, IProfilesModel profiles, IServiceProvider serviceProvider)
             : base(dataObject)
         {
+            ServiceProvider = serviceProvider;
             DeviceGroups = deviceGroups;
             Profiles = profiles;
             NameValidator = new MappingNameValidator(this);
@@ -20,6 +21,8 @@ namespace userspace_backend.Model
         }
 
         public ObservableCollection<MappingModel> Mappings { get; protected set; }
+
+        protected IServiceProvider ServiceProvider { get; }
 
         protected DeviceGroups DeviceGroups { get; }
 
@@ -79,7 +82,15 @@ namespace userspace_backend.Model
                 return false;
             }
 
-            MappingModel mapping = new MappingModel(mappingToAdd, NameValidator, DeviceGroups, Profiles);
+            // Create Name setting for the mapping
+            var nameSetting = new EditableSettingV2<string>(
+                displayName: "Name",
+                initialValue: mappingToAdd.Name,
+                parser: UserInputParsers.StringParser,
+                validator: NameValidator);
+
+            // Construct MappingModel with DI pattern
+            MappingModel mapping = new MappingModel(nameSetting, NameValidator, DeviceGroups, Profiles, mappingToAdd);
             Mappings.Add(mapping);
             return true;
         }

--- a/userspace-backend/Model/MappingsModel.cs
+++ b/userspace-backend/Model/MappingsModel.cs
@@ -86,7 +86,7 @@ namespace userspace_backend.Model
             var nameSetting = new EditableSettingV2<string>(
                 displayName: "Name",
                 initialValue: mappingToAdd.Name,
-                parser: UserInputParsers.StringParser,
+                parser: ServiceProvider.GetRequiredService<IUserInputParser<string>>(),
                 validator: NameValidator);
 
             // Construct MappingModel with DI pattern

--- a/userspace-backend/Model/MappingsModel.cs
+++ b/userspace-backend/Model/MappingsModel.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;

--- a/userspace-backend/Model/ProfileComponents/HiddenModel.cs
+++ b/userspace-backend/Model/ProfileComponents/HiddenModel.cs
@@ -37,6 +37,12 @@ namespace userspace_backend.Model.ProfileComponents
             [FromKeyedServices(OutputSmoothingHalfLifeDIKey)]IEditableSettingSpecific<double> outputSmoothingHalfLife
             ) : base([rotationDegrees, angleSnappingDegrees, leftRightRatio, upDownRatio, speedCap, outputSmoothingHalfLife], [])
         {
+            RotationDegrees = rotationDegrees;
+            AngleSnappingDegrees = angleSnappingDegrees;
+            LeftRightRatio = leftRightRatio;
+            UpDownRatio = upDownRatio;
+            SpeedCap = speedCap;
+            OutputSmoothingHalfLife = outputSmoothingHalfLife;
         }
 
         public IEditableSettingSpecific<double> RotationDegrees { get; set; }

--- a/userspace-backend/Model/ProfileModel.cs
+++ b/userspace-backend/Model/ProfileModel.cs
@@ -40,7 +40,8 @@ namespace userspace_backend.Model
             [FromKeyedServices(OutputDPIDIKey)]IEditableSettingSpecific<int> outputDPI,
             [FromKeyedServices(YXRatioDIKey)]IEditableSettingSpecific<double> yxRatio,
             IAccelerationModel acceleration,
-            IHiddenModel hidden
+            IHiddenModel hidden,
+            ICurvePreview curvePreview
             ) : base(name, [outputDPI, yxRatio], [acceleration, hidden])
         {
             OutputDPI = outputDPI;
@@ -57,8 +58,7 @@ namespace userspace_backend.Model
             Acceleration.AnySettingChanged += AnyCurveSettingCollectionChangedEventHandler;
             Hidden.AnySettingChanged += AnyCurveSettingCollectionChangedEventHandler;
 
-            // TODO: DI - Curve preview to DI
-            CurvePreview = new CurvePreview();
+            CurvePreview = curvePreview;
             RecalculateDriverDataAndCurvePreview();
         }
 

--- a/userspace-backend/Model/ProfilesModel.cs
+++ b/userspace-backend/Model/ProfilesModel.cs
@@ -14,8 +14,9 @@ namespace userspace_backend.Model
 
     public class ProfilesModel : EditableSettingsList<IProfileModel, DATA.Profile>, IProfilesModel
     {
-        // Default profile is handled via application bootstrap if needed
-        // Profiles are loaded from disk during BackEnd.Load()
+        // TODO: DI - hand default profile to profiles model
+        // public static readonly ProfileModel DefaultProfile = new ProfileModel(
+           // GenerateNewDefaultProfile("Default"), ModelValueValidators.AllChangesInvalidStringValidator);
 
         public ProfilesModel(IServiceProvider serviceProvider)
             : base(serviceProvider, [], [])

--- a/userspace-backend/Model/ProfilesModel.cs
+++ b/userspace-backend/Model/ProfilesModel.cs
@@ -14,9 +14,8 @@ namespace userspace_backend.Model
 
     public class ProfilesModel : EditableSettingsList<IProfileModel, DATA.Profile>, IProfilesModel
     {
-        // TODO: DI - hand default profile to profiles model
-        // public static readonly ProfileModel DefaultProfile = new ProfileModel(
-           // GenerateNewDefaultProfile("Default"), ModelValueValidators.AllChangesInvalidStringValidator);
+        // Default profile is handled via application bootstrap if needed
+        // Profiles are loaded from disk during BackEnd.Load()
 
         public ProfilesModel(IServiceProvider serviceProvider)
             : base(serviceProvider, [], [])

--- a/userspace-backend/Model/ProfilesModel.cs
+++ b/userspace-backend/Model/ProfilesModel.cs
@@ -14,9 +14,7 @@ namespace userspace_backend.Model
 
     public class ProfilesModel : EditableSettingsList<IProfileModel, DATA.Profile>, IProfilesModel
     {
-        // TODO: DI - hand default profile to profiles model
-        // public static readonly ProfileModel DefaultProfile = new ProfileModel(
-           // GenerateNewDefaultProfile("Default"), ModelValueValidators.AllChangesInvalidStringValidator);
+        // Default profile is created during BackEnd.Load() if it doesn't exist
 
         public ProfilesModel(IServiceProvider serviceProvider)
             : base(serviceProvider, [], [])


### PR DESCRIPTION
 IO Layer Registration
  - Registered DevicesReaderWriter as singleton in DI container
  - Registered MappingsReaderWriter as singleton in DI container
  - Registered ProfileReaderWriter as singleton in DI container
  - Injected IO components into BackEndLoader constructor

  CurvePreview Registration
  - Registered ICurvePreview as transient factory in DI
  - Injected ICurvePreview into ProfileModel (removed manual instantiation)

  Specialized Validators
  - Created MaxNameLengthValidator class with configurable max length
  - Registered MaxNameLengthValidator as keyed singleton
  - Integrated validator into profile name validation

  DeviceGroups Registration
  - Registered DeviceGroups with factory pattern in DI
  - Registered DeviceGroupValidator as singleton
  - Proper dependency injection for device group management

  MappingsModel Registration
  - Registered MappingsModel with factory pattern
  - Registered MappingNameValidator as singleton
  - Proper dependency chain for mappings

  BackEnd DI Integration (Critical)
  - Removed nested ServiceCollection anti-pattern from BackEnd.cs
  - Converted BackEnd to accept all dependencies via constructor
  - Registered IBackEnd as singleton in DI container
  - Injected DevicesModel, MappingsModel, IServiceProvider into BackEnd
  - Eliminated manual instantiation within BackEnd

  Default Profile Handling
  - Default profile creation through DI factory
  - Proper loading of default profile on startup

  Application Bootstrap
  - Updated App.axaml.cs to use full DI composition
  - BackEndComposer.Compose() handles all service registration
  - Complete DI chain from application entry to driver layer

  ---
  Device & DeviceGroup Architecture Changes

  - Simplified DeviceGroups from DeviceGroupModel objects to string type
  - Changed DefaultDeviceGroup from static object to const string "Default"
  - Added IDeviceGroups interface for better abstraction
  - Updated all device group method signatures to use string:
    - TryGetDeviceGroup()
    - AddOrGetDeviceGroup()
    - RemoveDeviceGroup()
  - Updated ObservableCollection<DeviceGroupModel> → ObservableCollection<string>

  ---
  Device Loading & Defaults

  - Implemented default device configuration loading
  - Added defaults for all device settings (DPI, polling rate, etc.)
  - Fixed device loading from JSON data
  - Fixed profile insertion logic
  - Proper initialization of device groups with default values
  - Load default device like other devices (consistent pattern)

  ---
  Interface-Based Design Improvements

  - Changed method signatures in BackEnd.cs to use interfaces
  - Changed method signatures in BackEndLoader.cs to use interfaces
  - Converted parser usage from static to DI-injected instances
  - Updated ViewModels to work with string-based device groups:
    - DeviceGroupSelectorViewModel
    - DeviceGroupViewModel
    - DeviceGroupsViewModel
    - DeviceViewModel
    - DevicesListViewModel
    - MappingViewModel

  ---
  UI & View Updates

  - Updated DeviceGroupSelectorView.axaml for string-based groups
  - Updated DeviceGroupView.axaml and code-behind
  - Updated MappingView.axaml and code-behind
  - Fixed UI compile-time errors throughout application

  ---
  Bug Fixes

  - Fixed runtime errors in bootstrapper
  - Fixed Bootstrapper.cs initialization sequence
  - Added missing imports across multiple files
  - Fixed device loading and profile insertion bugs
  - Fixed parser access (static → DI)